### PR TITLE
Fixed invalid OrderID length

### DIFF
--- a/Action/ConvertPaymentAction.php
+++ b/Action/ConvertPaymentAction.php
@@ -31,7 +31,7 @@ class ConvertPaymentAction implements ActionInterface
                 'Description' => $payment->getDescription(),
                 'Issuer' => $payment->getIssuer(),
                 'Language' => $payment->getLanguage(),
-                'OrderID' => uniqid($payment->getOrder()->getId() . '_'),
+                'OrderID' => substr(uniqid($payment->getOrder()->getId() . '_'), 0, 10),
                 'Paymentmethod' => $payment->getMethod(),
                 'Reference' => $payment->getId(),
             ]


### PR DESCRIPTION
IcePay validates the length of the OrderID now, the OrderID has a maximum length of 10 characters.